### PR TITLE
fix: substitute NAMESPACE into manifests before apply so --namespace is respected

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -374,6 +374,12 @@ deploy_operator() {
         echo -e "${YELLOW}Using existing image from manifest: ${EXISTING_IMAGE}${NC}"
     fi
 
+    # Substitute NAMESPACE into manifests (repo files are hardcoded to o2operator)
+    for f in manifests/*.yaml; do
+        [ -f "$f" ] || continue
+        sed "s/namespace: o2operator/namespace: ${NAMESPACE}/g; s/name: o2operator/name: ${NAMESPACE}/g" "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+    done
+
     # Apply namespace
     echo -e "${YELLOW}Creating namespace...${NC}"
     kubectl apply ${DRY_RUN} -f manifests/00-namespace.yaml


### PR DESCRIPTION
## Problem

`deploy.sh` accepts `--namespace <name>` but applied `manifests/00-namespace.yaml` as-is, so the namespace created was always `o2operator` regardless of the `--namespace` value. See [issue #1](https://github.com/openobserve/o2-k8s-operator/issues/1).

## Solution

Before applying any manifests, substitute the `NAMESPACE` variable (set from `--namespace`) into all manifest YAML files: replace `namespace: o2operator` and `name: o2operator` with the requested namespace. Uses portable `sed` (write to `.tmp` then `mv`) so it works on both macOS and Linux.

## Testing

- `./deploy.sh --namespace openobserve` now creates and uses the `openobserve` namespace instead of always creating `o2operator`.
- Default `./deploy.sh` (no `--namespace`) still deploys to `o2operator` since `NAMESPACE` defaults to `o2operator`.